### PR TITLE
Add template for creating How-To task articles

### DIFF
--- a/how-to-task-template.md
+++ b/how-to-task-template.md
@@ -1,0 +1,94 @@
+---
+title: Title of article
+type: article
+created_date: 'yyyy-mm-dd'
+created_by: First Last
+last_modified_date: 'yyyy-mm-dd'
+last_modified_by: First Last
+product: Product Name
+product_url: product-name
+---
+
+<!--
+For detailed guidelines for creating clear and effective tasks, see [the Tasks section of the style guide](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/m-z-style-guidelines.md#tasks).
+
+For guidelines specific to How-To articles, see [Contributing to the Rackspace How-To content repository](https://github.com/rackerlabs/rackspace-how-to/blob/master/CONTRIBUTING.md).
+
+For a good example article that illustrates most of the areas covered in this template, see https://github.com/rackerlabs/rackspace-how-to/blob/master/content/cloud-servers/migrating-an-application-built-on-a-lamp-stack-from-amazon-web-services.md.
+-->
+
+<!--
+Limit task topics to a single task or a closely related group of tasks. Include as much context as necessary for the user to be able to complete the task.
+
+Create a title (in the header section, above) that accurately describes the task. Start with an imperative verb, and use sentence-style capitalization. For example:
+
+Create and attach a volume
+Install or upgrade PHP 5.3 for CentOS 5.x
+-->
+
+This article describes *x* so that you can *y*.
+
+<!--
+To begin the article, provide a brief summary of what the article describes and why it matters. For example:
+
+"You can send email to a large number of people by assigning them to a parent email list called a group list. This article shows you how to create a group list."
+
+"To set up Webmail Mobile Sync with your Rackspace Email account on your mobile device, you need to add an ActiveSync or BlackBerry Enterprise Service (BES) license through the Cloud Office Control Panel. This article shows you how to add a ActiveSync or BES license."
+
+You are not limited to this phrasing, but ensure that the introduction adequately describes what the article is about.
+-->
+
+### Prerequisites
+
+<!--
+List necessary prerequisites for the task or set of tasks. Limit this section to only what the user needs to know or do to accomplish the task.
+
+- Software that must already be installed
+- Dependencies
+- Links to other articles
+- Any other required setup
+-->
+
+### Steps
+
+<!--
+If you have a "Prerequisites" section, or you have more than one procedure (set of steps) in the article, precede each list of steps with a descriptive heading. Begin the heading with  an imperative verb (for example, Create a scheduled backup). If an article has just one set of steps, and it is preceded by only a brief introduction, you can omit this heading.
+
+List steps in a numbered list. Limit each step to a single action. For detailed guidelines for writing effective and clear step text, see [the style guide](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/m-z-style-guidelines.md#tasks-steps).
+
+Include as many "Steps" sections as needed to provide a complete article to the user.
+
+To make it easier to shuffle steps around, number each with 1.; the processor handles numbering the steps appropriately.
+-->
+
+1. Do this.
+
+    Indent any descriptions or information needed between steps. If your task includes sublists, graphics, and code examples, use the spacing guidelines at https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#lists.
+
+1. Do that.
+
+1. Do this other thing.
+
+1. Clean up.
+
+Conclude with a brief description of the end state.
+
+### Troubleshooting
+
+<!--
+
+If there are known issues that the user could encounter during the task, describe those issues and their workarounds in this section. If the issues and workarounds are provided in another article, provide a link to that article.   
+
+-->
+
+### Related information
+
+<!--
+Provide links to related content.
+-->
+
+### Next step
+
+<!--
+If the task is part of a larger set of tasks, you can help the customer by including this section and a link to the next task article.
+-->


### PR DESCRIPTION
To help users who want to contribute articles to the How-To, I created a template for tasks. I based it on the template created for Carina, but added some extra guidelines and How-To specific examples and links. I'll be asking everyone to review and provide feedback. When it is done, we can move it to the how-to repo and link to it from the contributing file.