### PR TITLE
Fix style guide links in contributor collateral

### DIFF
--- a/doc/contributor-collateral/CONTRIBUTING.md
+++ b/doc/contributor-collateral/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributor guidelines
 
-These guidelines provide the general process for maintaining source code that builds the
-Rackspace Cloud Files developer documentation.
+These guidelines provide the general process for maintaining source code that
+builds the Rackspace Cloud Files developer documentation.
 
 - [Project description](#project-description)
 - [Updating and adding content](#updating-and-adding-content)
@@ -15,8 +15,9 @@ contributors figure out which file to update.-->
 
 This project is developed and built by using the
 [Python Sphinx documentation generator](http://sphinx-doc.org/). Content is
-written in [reStructuredText](http://sphinx-doc.org/rest.html), which is the markup syntax and
-parser component of [Python Docutils](http://docutils.sourceforge.net/index.html).
+written in [reStructuredText](http://sphinx-doc.org/rest.html), which is the markup
+syntax and parser component of
+[Python Docutils](http://docutils.sourceforge.net/index.html).
 
 Source files for the Sphinx documentation project are in the ``api-docs`` directory.
 Following are the key files that define project and content architecture:
@@ -46,12 +47,14 @@ Content | File
 |Windows build script|``make.bat``|
 <!--endtable-->
 
-
 ## Updating and adding content
 
-Contributions are submitted, reviewed, and accepted by using GitHub pull requests, following the [GitHub workflow](GITHUBING.md) for this repository.
+Contributions are submitted, reviewed, and accepted by using GitHub
+pull requests, following the [GitHub workflow](GITHUBING.md) for this
+repository.
 
-To update existing source files or add new ones, follow the [GitHub workflow](GITHUBING.md) for this repository.
+To update existing source files or add new ones, follow the
+[GitHub workflow](GITHUBING.md) for this repository.
 
 * Update source files by using the GitHub editor or any plain text editor.
 * Format source files with
@@ -61,8 +64,8 @@ To update existing source files or add new ones, follow the [GitHub workflow](GI
 
 ## General style guidelines
 
-When you add or update content, use the following general style guidelines, which are
-described in detail in [Style guidelines for technical content](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/README.md):
+When you add or update content, use the following general style guidelines,
+which are described in detail in [Style guidelines for technical content](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/README.md):
 
 - Use [sentence-style capitalization](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/a-l-style-guidelines.md#guidelines-for-sentence-style-capitalization) for titles and headings
 - Use consistent [text formatting](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/m-z-style-guidelines.md#text-formatting)
@@ -75,26 +78,33 @@ described in detail in [Style guidelines for technical content](https://github.c
 - Clarify [gerunds and participles](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#clarify-gerunds-and-participles)
 - Use [consistent terminology](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#use-consistent-terminology)
 
-<!-- Adding build from source guidelines until we can provide a link to automated gh-pages
-output, or to the staging URL that Ash is working on.
+<!-- Adding build from source guidelines until we can provide a link to automated
+gh-pages output, or to the staging URL that Ash is working on.
 -->
 
 ## Submitting changes
 
-When you've completed your changes, submit a pull request. Someone on the Information Development team will review your PR.
-- Minor updates and corrections get a quick review to ensure that content is error-free and doesn't introduce other issues.
+When you've completed your changes, submit a pull request. Someone on the
+Information Development team will review your PR.
+
+- Minor updates and corrections get a quick review to ensure that content is 
+  error-free and doesn't introduce other issues.
 - More complex changes or additions require both technical and editorial review.
 
 Depending on the review feedback, you might be asked to make additional changes.
 
-After content has been reviewed and approved, the updates can be merged to the master branch. The merge triggers the build and
-deploy process. Typically, new content is available on developer.rackspace.com within a minute or two after it is merged. Larger
-updates might take a bit longer.
+After content has been reviewed and approved, the updates can be merged to the
+master branch. The merge triggers the build and deploy process. Typically,
+new content is available on developer.rackspace.com within a minute or two after
+it is merged. Larger updates might take a bit longer.
 
 ## Previewing changes
 
-When you submit a pull request, the Strider build process creates a preview of your changes in a staging environment.
-After the build process completes, the following message displays in the pull request comments with a link to the content: ``Your content preview is now ready.``
+When you submit a pull request, the Strider build process creates
+a preview of your changes in a staging environment. After the build
+process completes, the following message displays in the pull request
+comments with a link to the content: ``Your content preview is now ready.``
 
-You can also build the project locally using the [Sphinx documentation generator](http://sphinx-doc.org/). For details, see
+You can also build the project locally using the
+[Sphinx documentation generator](http://sphinx-doc.org/). For details, see
 [Building from source](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/tools/build-from-source.rst).

--- a/doc/contributor-collateral/CONTRIBUTING.md
+++ b/doc/contributor-collateral/CONTRIBUTING.md
@@ -62,18 +62,18 @@ To update existing source files or add new ones, follow the [GitHub workflow](GI
 ## General style guidelines
 
 When you add or update content, use the following general style guidelines, which are
-described in detail in [Style guidelines for technical content](https://github.com/rackerlabs/docs-rackspace/tree/master/style-guide):
+described in detail in [Style guidelines for technical content](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/README.md):
 
-- Use [sentence-style capitalization](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/a-l-style-guidelines.md#cap-sentence-style) for titles and headings
-- Use consistent [text formatting](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/m-z-style-guidelines.md#text-formatting)
-- Write clear and consistent [code examples](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/a-l-style-guidelines.md#code-examples)
-- Use [active voice](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/basic-writing-guidelines.md#use-active-voice)
-- Use [present tense](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/basic-writing-guidelines.md#use-present-tense)
-- Write to the user by using [second person and imperative mood](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/basic-writing-guidelines.md#write-to-user)
-- Write clear and consistent [step text](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/m-z-style-guidelines.md#tasks-steps)
-- Clarify [pronouns](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/basic-writing-guidelines.md#clarify-pronouns) such as *it*, *this*, *there*, and *that*
-- Clarify [gerunds and participles](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/basic-writing-guidelines.md#clarify-gerunds-and-participles)
-- Use [consistent terminology](https://github.com/rackerlabs/docs-rackspace/blob/master/style-guide/basic-writing-guidelines.md#use-consistent-terminology)
+- Use [sentence-style capitalization](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/a-l-style-guidelines.md#guidelines-for-sentence-style-capitalization) for titles and headings
+- Use consistent [text formatting](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/m-z-style-guidelines.md#text-formatting)
+- Write clear and consistent [code examples](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/a-l-style-guidelines.md#code-examples)
+- Use [active voice](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#use-active-voice)
+- Use [present tense](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#use-present-tense)
+- Write to the user by using [second person and imperative mood](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#write-to-the-user-by-using-second-person-and-imperative-mood)
+- Use numbered lists for instructions, and write clear [step text](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/m-z-style-guidelines.md#procedural-steps)
+- Clarify [pronouns](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#clarify-pronouns) such as *it*, *this*, *there*, and *that*
+- Clarify [gerunds and participles](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#clarify-gerunds-and-participles)
+- Use [consistent terminology](https://github.com/rackerlabs/docs-rackspace/blob/master/doc/style-guide/basic-writing-guidelines.md#use-consistent-terminology)
 
 <!-- Adding build from source guidelines until we can provide a link to automated gh-pages
 output, or to the staging URL that Ash is working on.

--- a/doc/contributor-collateral/CONTRIBUTING.md
+++ b/doc/contributor-collateral/CONTRIBUTING.md
@@ -79,7 +79,7 @@ described in detail in [Style guidelines for technical content](https://github.c
 output, or to the staging URL that Ash is working on.
 -->
 
-# Submitting changes
+## Submitting changes
 
 When you've completed your changes, submit a pull request. Someone on the Information Development team will review your PR.
 - Minor updates and corrections get a quick review to ensure that content is error-free and doesn't introduce other issues.


### PR DESCRIPTION
New paths to GH topics include /docs, so I added that in.