### PR TITLE
fixed list guideline

### DIFF
--- a/doc/style-guide/a-l-style-guidelines.md
+++ b/doc/style-guide/a-l-style-guidelines.md
@@ -501,10 +501,10 @@ Begin the definition with a descriptive phrase. Capitalize the first letter of t
 
 How you begin the definition also depends on what part of speech the term is:
 
-- Noun&mdash;Begin with the appropriate article (a, an, or the) and a noun phrase.
-- Verb&mdash;Begin with the infinitive form of another verb that defines the term.
-- Adjective&mdash;Begin with a verb such as describes or pertains to.
-- Abbreviation&mdash;Begin with the spelled-out term.
+- Noun: Begin with the appropriate article (a, an, or the) and a noun phrase.
+- Verb: Begin with the infinitive form of another verb that defines the term.
+- Adjective: Begin with a verb such as describes or pertains to.
+- Abbreviation: Begin with the spelled-out term.
 
 The following table shows examples.
 
@@ -744,25 +744,25 @@ Use the following guidelines when writing list items:
 - Avoid using articles (*a*, *an*, *the*) to start list items.
 - When a list provides a series of terms or phrases and then more information about them, format the list as follows:
   - Show the term or phrase in bold. Using bold makes the list easier to scan.
-  - If you need to separate the initial term or phrase from the information that follows it, use an em dash with no spaces on either side of it. However, if you do not need a separator, don't use one. (For an example of a list in which em dash separators are not necessary, see the list at the top of this topic.)
+  - If you need to separate the initial term or phrase from the information that follows it, use a colon. However, if you do not need a separator, don't use one. (For an example of a list in which separators are not necessary, see the list at the top of this topic.)
 - Unless another order makes sense or is preferable, alphabetize list items.
 
 The following sections show examples of the indicated types of lists.
 
-#### All list items are sentences&mdash;example
+#### All list items are sentences, example
 When you create an isolated network, the following limitations apply:
 - The isolated network must exist in the same region as the server.
 - You can create up to three isolated networks with up to 64 servers attached to each one.
 - After you create an isolated network, you cannot rename it.
 
-#### All list items are fragments&mdash;example
+#### All list items are fragments, example
 The example creates a database instance called myrackinstance with the following characteristics:
 - 512 MB instance flavor
 - Volume size of 2 GB
 - Database named `sampledb` with a `utf8` character set and a `utf8_general_ci` collation
 - User named `simplestUser` with the password `password`
 
-#### All list items are imperative statements&mdash;example
+#### All list items are imperative statements, example
 You can use Cloud Backup to perform the following actions:
 - Select the files and folders from your server that you want to back up.
 - Run your backups manually or on a schedule.
@@ -772,13 +772,13 @@ You can use Cloud Backup to perform the following actions:
 - Save space with incremental backups that save only the changed portions of files.
 - Create unlimited backups.
 
-#### List items mix fragments and sentences&mdash;example
+#### List items mix fragments and sentences, example
 To run the examples in this guide, the following prerequisites are required:
 - Rackspace Cloud account. To sign up for a Rackspace Cloud account, go to the <u>Rackspace Public Cloud signup page</u>.
 - Rackspace user name and password that you specified during registration.
 
-#### List that provides terms and more information&mdash;example
+#### List that provides terms and more information, example
 You have the following choices for your virtual IP:
-- **Public**&mdash;This setting allows any two servers with public IP addresses to be load balanced. These can be nodes outside of the Rackspace network, but if they are, standard bandwidth rates apply.
-- **Shared Virtual IP**&mdash;Use this setting if you want to load-balance multiple services on different ports while using the same virtual IP address.
-- **Private Rackspace network**&mdash;This is the best option for load-balancing two Cloud Servers because it allows the load-balancing traffic to run on the Rackspace Cloud internal network, called ServiceNet. This option has two distinct advantages: the rate limit is double what the rate limit is on the public interface, and all traffic on the ServiceNet between Cloud Servers is not charged for bandwidth.
+- **Public**: This setting allows any two servers with public IP addresses to be load balanced. These can be nodes outside of the Rackspace network, but if they are, standard bandwidth rates apply.
+- **Shared Virtual IP**: Use this setting if you want to load-balance multiple services on different ports while using the same virtual IP address.
+- **Private Rackspace network**: This is the best option for load-balancing two Cloud Servers because it allows the load-balancing traffic to run on the Rackspace Cloud internal network, called ServiceNet. This option has two distinct advantages: the rate limit is double what the rate limit is on the public interface, and all traffic on the ServiceNet between Cloud Servers is not charged for bandwidth.

--- a/doc/style-guide/m-z-style-guidelines.md
+++ b/doc/style-guide/m-z-style-guidelines.md
@@ -277,6 +277,7 @@ Guideline | Example
 --- | ---
 Use a colon at the end of a sentence that introduces a list. If another sentence intervenes between the introductory sentence and the list, use a period instead of a colon. <br /><br /> **Note:** Use a sentence, rather than a fragment, to introduce a list. Fragments are difficult to translate and can be harder to comprehend than sentences, so avoid using them to introduce lists. | The following monitoring checks are available to users: <br /><br /> You can use this product to perform the following tasks: <br /><br /> You can use this product to perform the following tasks. You must extract objects from the database to complete these tasks.
 In steps, use a colon to introduce code that the user is expected to enter.	| Run the following command: <br /> `nova list`
+In a list item, if you need to separate an initial term or phrase from the information that follows it, use a colon. | **Public**: This setting allows any two servers with public IP addresses to be load balanced. These can be nodes outside of the Rackspace network, but if they are, standard bandwidth rates apply.
 Do not use a colon to end the introduction to a table, figure, or example. | The following figure shows an overview of Cloud Databases infrastructure. <br /><br /> In the following request example, `Content-Type` is set to `application/json`, but `application/xml` is requested in the `Accept` header. <br /><br /> Table 5.1 lists the endpoints to use for your Cloud Databases API calls.
 Do not use a colon at the end a table column header, a title, or a heading. | 3.2. Service Endpoints <br /><br /> To create a monitoring check <br /><br /> Table 3.1. Regionalized Service Endpoints <br /><br /> Example 4.4. List Versions Response: JSON
 <!--endtable-->
@@ -299,13 +300,9 @@ When a month, day, and year are embedded in a sentence, use a comma before and a
 <!--endtable-->
 
 ### Dashes
-An *em dash* is the longest dash. Use em dashes sparingly, and mostly in the following situations:
+An *em dash* is the longest dash. You can use em dashes to set off a long qualifier in the middle of a sentence if the use of commas would hinder readability. If you use em dashes for this purpose, do not use spaces around them.
 
-- In a list item, if you need to separate an initial term or phrase from the information that follows it, use an em dash with no spaces on either side of it.
-
-- You can use em dashes to set off a long qualifier in the middle of a sentence if the use of commas would hinder readability. If you do use em dashes for this purpose, do not use spaces around them.
-
-Do not use an em dash to separate a long sentence into two parts. Instead, create two sentences. In most cases, other forms of punctuation are more effective for clarity.
+Don't use an em dash to separate a long sentence into two parts. Instead, create two sentences.
 
 An *en dash* is longer than a hyphen and shorter than an em dash. Use an en dash for the following purposes:
 
@@ -899,7 +896,7 @@ Observe the following general guidelines when formatting text:
 
 - To apply a font treatment, use the appropriate markup in your authoring tool. In RST, use a directive if one is available. See the tables in this section for details.
 
-  **Note:** Apply directives only if the style sheet has been updated to support them. If they are not supported, apply formatting manually. 
+  **Note:** Apply directives only if the style sheet has been updated to support them. If they are not supported, apply formatting manually.
 
 - Do not apply font treatments to text elements in titles and headings.
 - Do not use capitalization to emphasize a term (for example, showing a general term in all capitals). Follow the capitalization that is normally used for a term, or follow the capitalization guidelines in the following table. For more information, see [Capitalization](../a-l-style-guidelines.html#capitalization).


### PR DESCRIPTION
Changed guideline from using an em dash, which requires HTML, to using a colon when setting a list item apart from its explanation. Fixed examples as needed. 