### PR TITLE
Adding quickstart to style guide

### DIFF
--- a/doc/style-guide/index.rst
+++ b/doc/style-guide/index.rst
@@ -11,6 +11,7 @@ consistent technical content for Rackspace customers.
 .. toctree::
    :maxdepth: 1
 
+   quickstart.rst
    writing/index.rst
    style/index.rst
    terminology/index.rst

--- a/doc/style-guide/quickstart.rst
+++ b/doc/style-guide/quickstart.rst
@@ -1,0 +1,125 @@
+.. _quickstart:
+
+==========
+Quickstart
+==========
+
+Thank you for contributing to Rackspace content!
+
+Don't worry if your job title doesn't include the word *writer*, *information*,
+or *content*—your most important contribution is your knowledge and expertise.
+Your willingness to share what you know with users will help them to accomplish
+their goals and be successful.
+
+The Information Development team is ready to help turn your contributions into
+clear, concise, consistent, easy-to-read content for users. We do this,
+in part, by adhering to the standards that are defined in this style guide.
+The team doesn't expect contributors to know or adhere to any of
+these guidelines; however, if you are interested in improving your writing or
+learning some of the style standards at Rackspace, we invite you to explore
+the guidelines.
+
+They are divided into the following categories:
+
+- **Writing guidelines** provide advice for writing content that is clear,
+  active, direct, and grammatically correct. In this section you'll encounter
+  grammatical terms like *voice*, *tense*, and *mood*, but don't let that deter
+  you from learning some fundamental standards for good technical writing.
+
+- **Style guidelines** provide information about how certain elements appear in
+  Rackspace content—for example, how we show abbreviations, how we capitalize
+  headings, whether we allow contractions, what formatting we apply to
+  certain text.
+
+- **Terminology guidelines** provide advice for using accurate, consistent, and
+  concise terminology in your content, and for writing for a global audience.
+
+- **Screenshot and diagram guidelines** provide instructions for when to use
+  and how to create screenshots and diagrams to enhance your content.
+
+- **Release notes guidelines** provide instructions specifically for writing
+  release notes for Rackspace Cloud services APIs. You can use these basic
+  guidelines, however, when writing release notes for any product.
+
+The style guide includes hundreds of guidelines, but you can start with the
+following guidelines to help you boost the effectiveness of your writing.
+
+.. list-table::
+   :widths: 80 20
+   :header-rows: 1
+
+   * - Guideline
+     - More information and examples
+   * - Write in *active voice*.
+
+       Active voice makes the performer of the action (usually the user) the
+       subject of the sentence. Active-voice sentences are more direct and
+       easier to understand than passive-voice sentences.
+     - :ref:`use-active-voice`
+   * - Use *present tense*.
+
+       Users read content to help them perform tasks or to gather
+       information. These activities occur in the users' present
+       time, so the present tense is appropriate in most content.
+     - :ref:`use-present-tense`
+   * - Write to the user by using *second person* and *imperative mood*.
+
+       Users are more engaged with content when it talks to them directly.
+       You talk to users directly by using second person, addressing the user
+       as *you*. When you use second person with the imperative mood (in which
+       the subject *you* is understood) *and* active voice, you make the text
+       clear, concise, and direct.
+     - :ref:`write-to-the-user`
+   * - Write *short sentences* and *short paragraphs*, and use *lists* whenever
+       possible.
+
+       Even a well-written long sentence can be hard to follow and understand,
+       so try to limit them to 25 words. Short paragraphs are easier to
+       scan and understand than longer ones. When listing three or more items,
+       use a bullet list instead of embedding the items in a paragraph.
+     - :ref:`write-clear-concise-sentences-paragraphs`
+   * - Use *action-oriented verbs*.
+
+       Verbs carry the action in a sentence, and they make your content come
+       alive for users. To make the biggest impact with your writing, use
+       strong, simple, action verbs.
+     - :ref:`use-effective-verbs`
+   * - Write clear and brief *step text*.
+
+       When you write instructions for users, write short steps, number them,
+       and use active voice and imperative mood.
+     - :ref:`tasks`
+   * - Clarify pronouns such as *it*, *this*, *there*, and *that*.
+
+       Pronouns are useful, but you must ensure that their antecedents (the
+       words that they are used in place of) are clear, and that they (the
+       pronouns) don’t cause vagueness and ambiguity.
+     - :ref:`use-pronouns-carefully`
+   * - Use *correct punctuation*.
+
+       Use periods to end most sentences, and use serial commas.
+     - :ref:`use-correct-punctuation`
+
+       :ref:`punctuation`
+   * - Use *sentence-style capitalization* for all titles and headings.
+
+       In sentence-style capitalization, you capitalize only the first word
+       of the title or heading, plus any proper nouns, proper adjectives,
+       and terms that are always capitalized, such as some abbreviations.
+     - :ref:`titles-and-headings`
+   * - Write clear and consistent *code examples*.
+
+       When you create blocks of code as input or output examples, follow some
+       basic guidelines to make them clear to users.
+     - :ref:`code-examples`
+   * - Use *consistent and simple terminology*.
+
+       Use short, simple words, and use them as they are defined in a general
+       or accepted industry dictionary. Each word or phrase should have only
+       one meaning that is used consistently throughout the content. Avoid
+       using humor, jargon, and metaphors.
+     - :ref:`alphabetical-list-of-terms`
+
+       :ref:`concise-terms`
+
+       :ref:`terms-for-global-audience`

--- a/doc/style-guide/style/punctuation.rst
+++ b/doc/style-guide/style/punctuation.rst
@@ -54,8 +54,13 @@ Use the following guidelines for colons:
 
 - Don't use a colon at the end a table column header, a title, or a heading.
 
-- Don't capitalize the word that follows a colon in a sentence, unless the word
-  is proper or is the beginning of a quotation.
+- Avoid using colons in sentences. You can almost always use two sentences
+  instead. If you do use a colon in a sentence, however, don't capitalize the
+  word that follows the colon unless the word is proper or is the beginning of
+  a quotation.
+
+- If a title or heading includes a colon, capitalize the first word that
+  follows the colon, regardless of its part of speech.
 
 Commas
 ~~~~~~

--- a/doc/style-guide/writing/use-pronouns-carefully.rst
+++ b/doc/style-guide/writing/use-pronouns-carefully.rst
@@ -6,7 +6,7 @@ Use pronouns carefully
 
 Pronouns are useful, but you must ensure that their antecedents (the
 words that they are used in place of) are clear, and that they (the
-pronouns) don’t contribute to vagueness and ambiguity.
+pronouns) don’t cause vagueness and ambiguity.
 
 The following pronouns often cause problems, so use them carefully: *it*,
 *this*, *there*, and *that*.

--- a/doc/style-guide/writing/write-clear-concise-sentences-paragraphs.rst
+++ b/doc/style-guide/writing/write-clear-concise-sentences-paragraphs.rst
@@ -170,3 +170,5 @@ list makes it easy for the user to scan the text.
        you select for deletion are highlighted with a dark gray background.
        When you delete a file, it's permanently removed from the Cloud Files
        container.
+
+For style guidelines for lists, see :ref:`lists`.


### PR DESCRIPTION
First draft of quickstart as a starting place for contributors. It takes the place of the "lite style guide" file in other repos such as how-to. 