### PR TITLE
Remove templates from index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,5 @@ includes information about how to contribute to blog.rackspace.com.
 
    contributor-collateral/index.rst
    style-guide/index.rst
-   templates/index.rst
    tools/index.rst
    outreach/rack-blog-post-process.rst


### PR DESCRIPTION
How To templates are in the rackspace-how-to repo and the other files for issues is not actively use.